### PR TITLE
Enhancement: Fixed language display

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-frontend/presets/* linguist-vendored
+frontend/presets/** linguist-vendored


### PR DESCRIPTION
Correctly displays the most important languages by excluding the `/frontend/presets/**` folder